### PR TITLE
Fix compilation errors

### DIFF
--- a/src/ancs_ble_client.h
+++ b/src/ancs_ble_client.h
@@ -3,7 +3,8 @@
 
 #include "ble_notification.h"
 
-#include "FreeRTOS.h" // For asynchronous tasks
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
 
 class BLEAddress;
 class BLERemoteCharacteristic;
@@ -37,7 +38,7 @@ public:
 	static void startClientTask(void *data);
 	
 public:
-	xTaskHandle clientTaskHandle;
+	TaskHandle_t clientTaskHandle;
 	
 	void onDataSourceNotify(BLERemoteCharacteristic*, uint8_t*, size_t, bool);
 	void onNotificationSourceNotify(BLERemoteCharacteristic*, uint8_t*, size_t, bool);

--- a/src/ble_security.cpp
+++ b/src/ble_security.cpp
@@ -21,7 +21,7 @@ bool NotificationSecurityCallbacks::onSecurityRequest(){
     return true;
 }
 
-bool NotificationSecurityCallbacks::onConfirmPIN(unsigned int){
+bool NotificationSecurityCallbacks::onConfirmPIN(uint32_t pint){
     ESP_LOGI(LOG_TAG, "On Confirmed Pin Request");
     return true;
 }

--- a/src/ble_security.h
+++ b/src/ble_security.h
@@ -11,7 +11,7 @@ class NotificationSecurityCallbacks : public BLESecurityCallbacks {
 
     bool onSecurityRequest();
     
-    bool onConfirmPIN(unsigned int);
+    bool onConfirmPIN(uint32_t pin);
 
     void onAuthenticationComplete(esp_ble_auth_cmpl_t cmpl);
 };

--- a/src/esp32notifications.cpp
+++ b/src/esp32notifications.cpp
@@ -108,11 +108,15 @@ bool BLENotifications::begin(const char * name) {
 	BLEDevice::setSecurityCallbacks(new NotificationSecurityCallbacks()); // @todo memory leak?
 	
 	startAdvertising();
+
+	return true;
 }
 
 bool BLENotifications::stop() {
 	ESP_LOGI(LOG_TAG, "stop()");
 	BLEDevice::deinit(false);	
+
+	return true;
 }
 
 

--- a/src/esp32notifications.cpp
+++ b/src/esp32notifications.cpp
@@ -136,14 +136,12 @@ void BLENotifications::begin(const char * name) {
 	
 	startAdvertising();
 
-	return true;
 }
 
 void BLENotifications::stop() {
 	ESP_LOGI(LOG_TAG, "stop()");
 	BLEDevice::deinit(false);	
 
-	return true;
 }
 
 void BLENotifications::setConnectionStateChangedCallback(ble_notifications_state_changed_t callback, const void *userData) {


### PR DESCRIPTION
Merges the fix from [Biospank's fork from upstream](https://github.com/biospank/ESP32-ANCS-Notifications) to fix [upstream issue #27](https://github.com/Smartphone-Companions/ESP32-ANCS-Notifications/issues/27), along with a few minor return statement tweaks. It now compiles successfully, though my tests of your WatchyBLEClient code were unsuccessful (it didn't stay connected to the phone for long, and would just give the "please play media on your phone" prompt when connected). 